### PR TITLE
Override homepage a11y warning

### DIFF
--- a/src/docs/Index.stories.tsx
+++ b/src/docs/Index.stories.tsx
@@ -4,6 +4,20 @@ export default {
   title: 'Home',
   parameters: {
     layout: 'fullscreen',
+    a11y: {
+      /* Prevent a11y tests displaying on homepage */
+      config: {
+        rules: [
+          {
+            id: 'color-contrast',
+            selector: '.evg-text-size-heading-lg',
+            enabled: false,
+            reason:
+              'Text over image with sufficient contrast verified manually',
+          },
+        ],
+      },
+    },
   },
   tags: ['!autodocs'],
 };


### PR DESCRIPTION
A11y warning opens every time the page loads. 

Test is incomplete due to the supergraphic preventing color contrast checker to run, but contrast is good.