### PR TITLE
fix: evergreen tweaks from accounts app build (WRAP-2274)

### DIFF
--- a/.storybook/DocPage.tsx
+++ b/.storybook/DocPage.tsx
@@ -44,9 +44,11 @@ export const DocPage = ({ of }: { of: any }) => {
               </evg-badge>
             )}
             {themeSupport && (
-              <evg-badge variant="sky-light">
-                Theme support
-              </evg-badge>
+              <a href="/?path=/docs/foundations-utilities-theme--docs">
+                <evg-badge variant="sky-light">
+                  Theme support
+                </evg-badge>
+              </a>
             )}
           </evg-row>
 

--- a/.storybook/DocPage.tsx
+++ b/.storybook/DocPage.tsx
@@ -44,7 +44,7 @@ export const DocPage = ({ of }: { of: any }) => {
               </evg-badge>
             )}
             {themeSupport && (
-              <a href="/?path=/docs/foundations-utilities-theme--docs">
+              <a href="/?path=/docs/guides-theming--docs">
                 <evg-badge variant="sky-light">
                   Theme support
                 </evg-badge>

--- a/src/components/canvas/Header/Header.stories.tsx
+++ b/src/components/canvas/Header/Header.stories.tsx
@@ -57,7 +57,7 @@ export default {
   },
 } satisfies Meta;
 
-const Template: StoryFn = ({ theme, compact, ...props }) => {
+const Template: StoryFn = ({ theme, compact, slot, ...props }) => {
   const [active, setActive] = useState('');
 
   const primary = [
@@ -80,7 +80,7 @@ const Template: StoryFn = ({ theme, compact, ...props }) => {
   ];
 
   return (
-    <>
+    <header slot={slot}>
       <evg-header class={`evg-theme-${theme}`} compact={compact} {...props}>
         <evg-header-logo>
           <a href="https://wrap.ngo">
@@ -189,7 +189,7 @@ const Template: StoryFn = ({ theme, compact, ...props }) => {
       <AboutUs open={active === 'about-us'} />
       <Regions open={active === 'regions'} />
       <Drawer />
-    </>
+    </header>
   );
 };
 

--- a/src/components/composition/FormGroup/FormGroup.stories.tsx
+++ b/src/components/composition/FormGroup/FormGroup.stories.tsx
@@ -72,3 +72,25 @@ ComposingElements.parameters = {
     },
   },
 };
+
+export const FormGroupFieldset: StoryFn = () => (
+  <fieldset>
+    <legend className="evg-spacing-md">Update password</legend>
+    <evg-form-group class="evg-spacing-md">
+      <evg-label>
+        <label htmlFor="new-password">New password</label>
+      </evg-label>
+      <evg-input>
+        <input id="new-password" type="password" />
+      </evg-input>
+    </evg-form-group>
+    <evg-form-group>
+      <evg-label>
+        <label htmlFor="confirm-password">Confirm password</label>
+      </evg-label>
+      <evg-input>
+        <input id="confirm-password" type="password" />
+      </evg-input>
+    </evg-form-group>
+  </fieldset>
+);

--- a/src/components/composition/FormGroup/FormGroup.stories.tsx
+++ b/src/components/composition/FormGroup/FormGroup.stories.tsx
@@ -72,25 +72,3 @@ ComposingElements.parameters = {
     },
   },
 };
-
-export const FormGroupFieldset: StoryFn = () => (
-  <fieldset>
-    <legend className="evg-spacing-md">Update password</legend>
-    <evg-form-group class="evg-spacing-md">
-      <evg-label>
-        <label htmlFor="new-password">New password</label>
-      </evg-label>
-      <evg-input>
-        <input id="new-password" type="password" />
-      </evg-input>
-    </evg-form-group>
-    <evg-form-group>
-      <evg-label>
-        <label htmlFor="confirm-password">Confirm password</label>
-      </evg-label>
-      <evg-input>
-        <input id="confirm-password" type="password" />
-      </evg-input>
-    </evg-form-group>
-  </fieldset>
-);

--- a/src/components/content/Icon/Icon.stories.tsx
+++ b/src/components/content/Icon/Icon.stories.tsx
@@ -19,7 +19,7 @@ Icons must have the appropriate fill or stroke set to \`currentColor\`.
 Icons are hidden from screen readers by default and should be accompanied by text.
 If an icon is used on its own in a button or link, add a \`label\` prop to the component.
 
-Evergreen uses default icons from [mono icons](https://icons.mono.company/) and adds
+Evergreen uses [default icons](/?path=/docs/foundations-icons--docs) from mono icons and adds
 some custom icons just for this library.
 
 There are two sets of branded icons that were created when redesigning wrap.ngo

--- a/src/components/content/Label/Label.stories.tsx
+++ b/src/components/content/Label/Label.stories.tsx
@@ -58,7 +58,7 @@ export const Legend: StoryFn = () => (
 export const ScreenReaderOnly: StoryFn = () => (
   <>
     <p>The invisible label content below is read by screen readers</p>
-    <evg-label className="evg-sr-only">
+    <evg-label class="evg-sr-only">
       <label htmlFor="input-with-sr-label">Label</label>
     </evg-label>
   </>

--- a/src/components/control/Button/Button.scss
+++ b/src/components/control/Button/Button.scss
@@ -138,13 +138,8 @@ evg-button {
   }
 
   &[size='sm'] {
-    evg-loading-button,
-    button,
-    a,
-    input {
-      --_padding-block: var(--evg-spacing-xs);
-      --_padding-inline: var(--evg-spacing-md);
-    }
+    --_padding-block: var(--evg-spacing-xs);
+    --_padding-inline: var(--evg-spacing-md);
   }
 
   &[width='full-width'] {
@@ -174,7 +169,7 @@ evg-button {
   }
 
   &[width='square'] {
-    --_padding-inline: var(--evg-button-padding-block);
+    --_padding-inline: var(--_padding-block);
 
     evg-loading-button,
     button,
@@ -207,7 +202,7 @@ evg-button {
     --_padding-inline: 0;
 
     &[width='square'] {
-      --_padding-inline: var(--evg-button-padding-block);
+      --_padding-inline: var(--_padding-block);
 
       evg-loading-button,
       button,

--- a/src/components/control/Button/Button.scss
+++ b/src/components/control/Button/Button.scss
@@ -208,8 +208,8 @@ evg-button {
       button,
       a,
       input {
-        // Remove padding whilst retaining a clickable area large enough for thumbs
-        margin: calc(var(--_padding-block) * -1);
+        // Remove padding and border whilst retaining a clickable area large enough for thumbs
+        margin: calc(var(--_padding-block) * -1 - 1px);
       }
     }
 

--- a/src/components/control/Button/Button.stories.tsx
+++ b/src/components/control/Button/Button.stories.tsx
@@ -105,26 +105,30 @@ export const Sizes: StoryFn = () => (
 export const IconOnlyButton: StoryFn = () => (
   <evg-grid wrap="wrap" align-items="center">
     <evg-grid-item>
+      <evg-button width="square" size="sm">
+        <button type="button" aria-label="Button text">
+          <evg-icon icon="email" />
+        </button>
+      </evg-button>
+    </evg-grid-item>
+    <evg-grid-item>
       <evg-button width="square">
         <button type="button" aria-label="Button text">
-          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-            <path
-              d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-              fill="currentColor"
-            ></path>
-          </svg>
+          <evg-icon icon="email" />
+        </button>
+      </evg-button>
+    </evg-grid-item>
+    <evg-grid-item>
+      <evg-button variant="ghost" width="square" size="sm">
+        <button type="button" aria-label="Button text">
+          <evg-icon icon="email" />
         </button>
       </evg-button>
     </evg-grid-item>
     <evg-grid-item>
       <evg-button variant="ghost" width="square">
         <button type="button" aria-label="Button text">
-          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-            <path
-              d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-              fill="currentColor"
-            ></path>
-          </svg>
+          <evg-icon icon="email" />
         </button>
       </evg-button>
     </evg-grid-item>

--- a/src/components/control/Input/Input.scss
+++ b/src/components/control/Input/Input.scss
@@ -78,6 +78,10 @@ evg-input {
     resize: vertical;
   }
 
+  evg-button[variant='ghost'] :is(button, a) {
+    min-height: 0;
+  }
+
   evg-icon,
   svg {
     align-self: center;

--- a/src/components/control/Input/Input.scss
+++ b/src/components/control/Input/Input.scss
@@ -1,7 +1,8 @@
 evg-input {
   --_background: var(--evg-input-background);
   --_border-color: var(--evg-input-border);
-  --evg-icon-baseline-adjust: 0.1em;
+  --evg-icon-size: 1.25rem;
+  --evg-icon-baseline-adjust: 0;
 
   align-items: center;
   background: var(--_background);
@@ -77,6 +78,7 @@ evg-input {
     resize: vertical;
   }
 
+  evg-icon,
   svg {
     align-self: center;
     block-size: var(--evg-icon-size);

--- a/src/components/control/Input/Input.stories.tsx
+++ b/src/components/control/Input/Input.stories.tsx
@@ -73,12 +73,12 @@ export const Affix: StoryFn = () => (
       <evg-grid-item>
         <evg-input>
           <evg-icon icon="email" />
-          <input value="prefix" />
+          <input value="Prefix" />
         </evg-input>
       </evg-grid-item>
       <evg-grid-item>
         <evg-input>
-          <input value="suffix" />
+          <input value="Suffix" />
           <evg-icon icon="email" />
         </evg-input>
       </evg-grid-item>
@@ -95,12 +95,12 @@ export const Affix: StoryFn = () => (
               <evg-icon icon="email" />
             </button>
           </evg-button>
-          <input value="prefix" />
+          <input value="Prefix" />
         </evg-input>
       </evg-grid-item>
       <evg-grid-item>
         <evg-input>
-          <input value="suffix" />
+          <input value="Suffix" />
           <evg-button variant="ghost" width="square">
             <button type="button" aria-label="Button text">
               <evg-icon icon="email" />
@@ -116,60 +116,24 @@ export const Affix: StoryFn = () => (
     <evg-grid wrap="wrap" class="evg-spacing-md">
       <evg-grid-item>
         <evg-input>
-          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+          <svg fill="none" viewBox="0 0 24 24" height="20" width="20">
             <path
               d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
               fill="currentColor"
             ></path>
           </svg>
-          <input value="prefix" />
+          <input value="Prefix" />
         </evg-input>
       </evg-grid-item>
       <evg-grid-item>
         <evg-input>
-          <input value="suffix" />
-          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+          <input value="Suffix" />
+          <svg fill="none" viewBox="0 0 24 24" height="20" width="20">
             <path
               d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
               fill="currentColor"
             ></path>
           </svg>
-        </evg-input>
-      </evg-grid-item>
-    </evg-grid>
-
-    <h2 className="evg-text-size-heading-sm evg-spacing-sm">
-      Affix icon with custom svg button
-    </h2>
-    <evg-grid wrap="wrap" class="evg-spacing-md">
-      <evg-grid-item>
-        <evg-input>
-          <evg-button variant="ghost" width="square">
-            <button type="button" aria-label="Button text">
-              <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-                <path
-                  d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </button>
-          </evg-button>
-          <input value="prefix" />
-        </evg-input>
-      </evg-grid-item>
-      <evg-grid-item>
-        <evg-input>
-          <input value="suffix" />
-          <evg-button variant="ghost" width="square">
-            <button type="button" aria-label="Button text">
-              <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-                <path
-                  d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </button>
-          </evg-button>
         </evg-input>
       </evg-grid-item>
     </evg-grid>

--- a/src/components/control/Input/Input.stories.tsx
+++ b/src/components/control/Input/Input.stories.tsx
@@ -65,30 +65,115 @@ export const InputStates: StoryFn = () => (
 );
 
 export const Affix: StoryFn = () => (
-  <evg-grid wrap="wrap">
-    <evg-grid-item>
-      <evg-input>
-        <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-          <path
-            d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-        <input value="prefix" />
-      </evg-input>
-    </evg-grid-item>
-    <evg-grid-item>
-      <evg-input>
-        <input value="suffix" />
-        <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
-          <path
-            d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-      </evg-input>
-    </evg-grid-item>
-  </evg-grid>
+  <div>
+    <h2 className="evg-text-size-heading-sm evg-spacing-sm">
+      Affix icon with evg-icon
+    </h2>
+    <evg-grid wrap="wrap" class="evg-spacing-md">
+      <evg-grid-item>
+        <evg-input>
+          <evg-icon icon="email" />
+          <input value="prefix" />
+        </evg-input>
+      </evg-grid-item>
+      <evg-grid-item>
+        <evg-input>
+          <input value="suffix" />
+          <evg-icon icon="email" />
+        </evg-input>
+      </evg-grid-item>
+    </evg-grid>
+
+    <h2 className="evg-text-size-heading-sm evg-spacing-sm">
+      Affix icon with evg-icon button
+    </h2>
+    <evg-grid wrap="wrap" class="evg-spacing-md">
+      <evg-grid-item>
+        <evg-input>
+          <evg-button variant="ghost" width="square">
+            <button type="button" aria-label="Button text">
+              <evg-icon icon="email" />
+            </button>
+          </evg-button>
+          <input value="prefix" />
+        </evg-input>
+      </evg-grid-item>
+      <evg-grid-item>
+        <evg-input>
+          <input value="suffix" />
+          <evg-button variant="ghost" width="square">
+            <button type="button" aria-label="Button text">
+              <evg-icon icon="email" />
+            </button>
+          </evg-button>
+        </evg-input>
+      </evg-grid-item>
+    </evg-grid>
+
+    <h2 className="evg-text-size-heading-sm evg-spacing-sm">
+      Affix icon with custom svg
+    </h2>
+    <evg-grid wrap="wrap" class="evg-spacing-md">
+      <evg-grid-item>
+        <evg-input>
+          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+            <path
+              d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+          <input value="prefix" />
+        </evg-input>
+      </evg-grid-item>
+      <evg-grid-item>
+        <evg-input>
+          <input value="suffix" />
+          <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+            <path
+              d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </evg-input>
+      </evg-grid-item>
+    </evg-grid>
+
+    <h2 className="evg-text-size-heading-sm evg-spacing-sm">
+      Affix icon with custom svg button
+    </h2>
+    <evg-grid wrap="wrap" class="evg-spacing-md">
+      <evg-grid-item>
+        <evg-input>
+          <evg-button variant="ghost" width="square">
+            <button type="button" aria-label="Button text">
+              <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+                <path
+                  d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </button>
+          </evg-button>
+          <input value="prefix" />
+        </evg-input>
+      </evg-grid-item>
+      <evg-grid-item>
+        <evg-input>
+          <input value="suffix" />
+          <evg-button variant="ghost" width="square">
+            <button type="button" aria-label="Button text">
+              <svg fill="none" viewBox="0 0 24 24" height="24" width="24">
+                <path
+                  d="M2 6C2 4.89543 2.89543 4 4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6ZM5.51859 6L12 11.6712L18.4814 6H5.51859ZM20 7.32877L12.6585 13.7526C12.2815 14.0825 11.7185 14.0825 11.3415 13.7526L4 7.32877V18H20V7.32877Z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </button>
+          </evg-button>
+        </evg-input>
+      </evg-grid-item>
+    </evg-grid>
+  </div>
 );
 
 export const Textarea: StoryFn = (args) => (

--- a/src/components/control/SkipLink/SkipLink.scss
+++ b/src/components/control/SkipLink/SkipLink.scss
@@ -13,6 +13,7 @@ evg-skip-link {
     text-underline-offset: 0.125em;
     transform: translateY(0);
     transition: var(--evg-transition);
+    z-index: 30;
 
     &:not(:focus) {
       transform: translateY(-100%);

--- a/src/docs/foundations/utilities/Spacing.stories.tsx
+++ b/src/docs/foundations/utilities/Spacing.stories.tsx
@@ -10,6 +10,8 @@ Spacing tweaks are one of the most common reasons for introducing page level CSS
 Individual components should not create spacing around themselves. Instead, they should use spacing classes to create the desired layout.
 
 It is generally recommended to use bottom spacing and no top spacing to prevent margin collapse.
+
+Because bottom spacing is preferred, this can be written without an explicit direction e.g.  \`evg-spacing-sm\`
 `;
 
 export default {
@@ -32,7 +34,7 @@ export default {
 };
 
 export const Spacing = (args) => {
-  const cx = `evg-spacing-bottom-${args.size}`;
+  const cx = `evg-spacing-${args.size}`;
 
   return (
     <>

--- a/src/docs/foundations/utilities/Text.stories.tsx
+++ b/src/docs/foundations/utilities/Text.stories.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 
 import { colors } from '@/lib/tokens';
 
+const families = ['heading', 'body'];
+
 const alignments = ['left', 'center', 'right'];
 
 const sizes = [
@@ -61,6 +63,12 @@ export default {
         type: 'select',
       },
       options: colors,
+    },
+    family: {
+      control: {
+        type: 'radio',
+      },
+      options: families,
     },
     size: {
       control: {

--- a/src/docs/recipes/App.stories.tsx
+++ b/src/docs/recipes/App.stories.tsx
@@ -17,17 +17,24 @@ export default {
 
 export function Brochureware({ children }) {
   return (
-    <evg-app>
-      <Light slot="header" />
-      {children ?? (
-        <evg-section padding="fluid" class="evg-theme-sand">
-          <evg-wrapper size="xxl">
-            <docs-placeholder>Content</docs-placeholder>
-          </evg-wrapper>
-        </evg-section>
-      )}
-      <Full slot="footer" />
-    </evg-app>
+    <>
+      <evg-skip-link>
+        <a href="#main">Skip to main content</a>
+      </evg-skip-link>
+      <evg-app>
+        <Light slot="header" />
+        <main id="main">
+          {children ?? (
+            <evg-section padding="fluid" class="evg-theme-sand">
+              <evg-wrapper size="xxl">
+                <docs-placeholder>Content</docs-placeholder>
+              </evg-wrapper>
+            </evg-section>
+          )}
+        </main>
+        <Full slot="footer" />
+      </evg-app>
+    </>
   );
 }
 
@@ -39,31 +46,45 @@ export function LaPortal({
   readonly children: React.ReactNode;
 }) {
   return (
-    <evg-app header="sticky">
-      <LaPortalHeader secondaryNav={secondaryNav} slot="header" />
-      {children ?? (
-        <evg-section padding="md">
-          <evg-wrapper size="xxl">
-            <docs-placeholder>Content</docs-placeholder>
-          </evg-wrapper>
-        </evg-section>
-      )}
-    </evg-app>
+    <>
+      <evg-skip-link>
+        <a href="#main">Skip to main content</a>
+      </evg-skip-link>
+      <evg-app header="sticky">
+        <LaPortalHeader secondaryNav={secondaryNav} slot="header" />
+        <main id="main">
+          {children ?? (
+            <evg-section padding="md">
+              <evg-wrapper size="xxl">
+                <docs-placeholder>Content</docs-placeholder>
+              </evg-wrapper>
+            </evg-section>
+          )}
+        </main>
+      </evg-app>
+    </>
   );
 }
 
 export function Data({ children }) {
   return (
-    <evg-app>
-      <DataHeader slot="header" />
-      {children ?? (
-        <evg-section padding="fluid" class="evg-theme-sand">
-          <evg-wrapper size="xxl">
-            <docs-placeholder>Content</docs-placeholder>
-          </evg-wrapper>
-        </evg-section>
-      )}
-      <Minimal slot="footer" />
-    </evg-app>
+    <>
+      <evg-skip-link>
+        <a href="#main">Skip to main content</a>
+      </evg-skip-link>
+      <evg-app>
+        <DataHeader slot="header" />
+        <main id="main">
+          {children ?? (
+            <evg-section padding="fluid" class="evg-theme-sand">
+              <evg-wrapper size="xxl">
+                <docs-placeholder>Content</docs-placeholder>
+              </evg-wrapper>
+            </evg-section>
+          )}
+        </main>
+        <Minimal slot="footer" />
+      </evg-app>
+    </>
   );
 }

--- a/src/docs/recipes/Header.stories.tsx
+++ b/src/docs/recipes/Header.stories.tsx
@@ -34,50 +34,52 @@ export function CompactDark(props) {
   return <Header theme="forest" compact {...props} />;
 }
 
-export function Data(props) {
+export function Data({ slot, ...props }) {
   return (
-    <evg-header class="evg-theme-default" {...props}>
-      <evg-header-logo>
-        <a href="https://wrap.ngo">
-          <img
-            src="/images/logo/forest.svg"
-            alt="WRAP logo"
-            width="110"
-            height="32"
-            loading="eager"
-          />
-        </a>
-      </evg-header-logo>
-      <evg-header-primary-nav>
-        <nav aria-label="Main navigation">
-          <evg-menu-item>
-            <a href="https://wrap.ngo">
-              <evg-menu-item-content>Data stories</evg-menu-item-content>
-            </a>
-          </evg-menu-item>
-        </nav>
-      </evg-header-primary-nav>
-      <evg-header-secondary-nav>
-        <nav aria-label="Secondary navigation">
-          <evg-button>
-            <a href="https://wrap.ngo">
-              Go to main site
-              <evg-icon icon="external-link" />
-            </a>
-          </evg-button>
-        </nav>
-      </evg-header-secondary-nav>
-      <evg-header-mobile-nav>
-        <nav aria-label="Mobile navigation">
-          <evg-button>
-            <a href="https://wrap.ngo">
-              Main site
-              <evg-icon icon="external-link" />
-            </a>
-          </evg-button>
-        </nav>
-      </evg-header-mobile-nav>
-    </evg-header>
+    <header slot={slot}>
+      <evg-header class="evg-theme-default" {...props}>
+        <evg-header-logo>
+          <a href="https://wrap.ngo">
+            <img
+              src="/images/logo/forest.svg"
+              alt="WRAP logo"
+              width="110"
+              height="32"
+              loading="eager"
+            />
+          </a>
+        </evg-header-logo>
+        <evg-header-primary-nav>
+          <nav aria-label="Main navigation">
+            <evg-menu-item>
+              <a href="https://wrap.ngo">
+                <evg-menu-item-content>Data stories</evg-menu-item-content>
+              </a>
+            </evg-menu-item>
+          </nav>
+        </evg-header-primary-nav>
+        <evg-header-secondary-nav>
+          <nav aria-label="Secondary navigation">
+            <evg-button>
+              <a href="https://wrap.ngo">
+                Go to main site
+                <evg-icon icon="external-link" />
+              </a>
+            </evg-button>
+          </nav>
+        </evg-header-secondary-nav>
+        <evg-header-mobile-nav>
+          <nav aria-label="Mobile navigation">
+            <evg-button>
+              <a href="https://wrap.ngo">
+                Main site
+                <evg-icon icon="external-link" />
+              </a>
+            </evg-button>
+          </nav>
+        </evg-header-mobile-nav>
+      </evg-header>
+    </header>
   );
 }
 
@@ -90,7 +92,7 @@ export function LaPortal({
   readonly slot?: string;
 }) {
   return (
-    <div slot={slot} {...props}>
+    <header slot={slot} {...props}>
       <evg-header compact class="evg-theme-forest">
         <evg-header-logo>
           <img
@@ -154,6 +156,6 @@ export function LaPortal({
           </nav>
         </evg-header>
       )}
-    </div>
+    </header>
   );
 }

--- a/src/styles/base/_forms.scss
+++ b/src/styles/base/_forms.scss
@@ -5,7 +5,8 @@ fieldset {
 }
 
 legend {
-  font-size: var(--evg-font-size-body-md);
+  color: var(--evg-theme-color);
+  font-size: var(--evg-font-size-body-sm);
   font-weight: var(--evg-font-weight-bold);
 }
 

--- a/src/styles/base/_forms.scss
+++ b/src/styles/base/_forms.scss
@@ -4,6 +4,11 @@ fieldset {
   padding: 0;
 }
 
+legend {
+  font-size: var(--evg-font-size-body-md);
+  font-weight: var(--evg-font-weight-bold);
+}
+
 button,
 input,
 optgroup,

--- a/src/styles/base/_scaffolding.scss
+++ b/src/styles/base/_scaffolding.scss
@@ -31,5 +31,6 @@ img {
 
 hr {
   border: 0 none;
-  border-bottom: 1px solid var(--evg-theme-border-color);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--evg-theme-color), transparent 80%);
 }

--- a/src/styles/utilities/spacing.scss
+++ b/src/styles/utilities/spacing.scss
@@ -12,4 +12,11 @@ $directions: top, left, bottom, right;
       }
     }
   }
+
+  // Down is preferred so it can be shorthand e.g. .evg-spacing-md
+  @each $size in spacing.$sizes {
+    &-#{$size} {
+      margin-bottom: var(--evg-spacing-#{$size});
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Evergreen tweaks surfaced while building the Accounts app (WRAP-2274). A collection of small fixes and docs improvements across control components, foundations and recipes.

## Changes

- **fix:** `evg-icon` and custom SVGs in input affixes now render at the same size
- **fix:** skip link no longer sits behind the header
- **fix:** `hr` colour now references a token that exists
- **fix:** button focus/styling tweaks
- **feat:** legend styling brought in line with labels
- **feat:** bottom spacing shorthand utility
- **docs:** font family text util docs
- **docs:** remove dead link to mono icons
- **docs:** theme support badge now links to theme docs

## Testing

- Storybook stories updated (Button, Input, Header, Icon, Label, Spacing, Text, App/Header recipes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
